### PR TITLE
feat(upload): add `randomPostKeys` option

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,7 @@
     "no-multi-assign": 0,
     "no-param-reassign": 0,
     "no-confusing-arrow": 0,
+    "no-shadow": 0,
     "max-len": [ 1, 120, 2, { "ignoreComments": true } ],
     "comma-dangle": [ 2, "never" ],
     "new-cap": [ 2, { "newIsCap": true, "capIsNew": false } ],

--- a/package.json
+++ b/package.json
@@ -22,12 +22,13 @@
   },
   "homepage": "https://github.com/bjyoungblood/hapi-serve-s3#readme",
   "dependencies": {
-    "aws-sdk": "^2.32.0",
-    "boom": "^4.3.0",
+    "aws-sdk": "^2.33.0",
+    "boom": "^4.3.1",
     "content": "^3.0.3",
     "content-disposition": "^0.5.2",
     "hoek": "^4.1.0",
-    "joi": "^10.3.1"
+    "joi": "^10.3.1",
+    "uuid": "^3.0.1"
   },
   "devDependencies": {
     "eslint": "^3.18.0",

--- a/src/schemas.js
+++ b/src/schemas.js
@@ -60,6 +60,9 @@ Schemas.routeOptionsSchema = Joi.object()
       )
       .optional(),
 
+    // If set, randomizes the S3 Key (basename) for POST request
+    randomPostKeys: Joi.boolean().optional(),
+
     // Specifies whether to include the Content-Disposition header.
     // - if `false`: no content-disposition header will be set
     // - if `auto`:

--- a/src/upload.js
+++ b/src/upload.js
@@ -60,10 +60,12 @@ Upload.handler = function (request, reply) {
 
   // resolve `bucket` and `key`
   const getBucketAndKey = function (file) {
+    const { randomPostKeys: randomize } = request.route.settings.plugins.s3;
+
     return Promise
       .all([
         Helpers.getBucket(request),
-        Helpers.getKey(request, { fileKey: file.key })
+        Helpers.getKey(request, { fileKey: file.key, randomize })
       ])
       .then(([bucket, key]) => [file, bucket, key]);
   };
@@ -203,6 +205,7 @@ Upload.handler = function (request, reply) {
 Upload.handler.defaults = {
   payload: {
     output: 'stream',
-    parse: true
+    parse: true,
+    maxBytes: 1024 * 1024 * 10 // 10MB
   }
 };

--- a/test/fixtures/buckets/test/files2/deeper/3.pdf/.dummys3_content
+++ b/test/fixtures/buckets/test/files2/deeper/3.pdf/.dummys3_content
@@ -1,0 +1,4 @@
+test3
+test3
+test3
+test3

--- a/test/fixtures/buckets/test/files2/deeper/3.pdf/.dummys3_metadata
+++ b/test/fixtures/buckets/test/files2/deeper/3.pdf/.dummys3_metadata
@@ -1,0 +1,10 @@
+{
+  "md5": "924a258504e85340c9497c9a60a81916",
+  "contentType": "application/octet-stream",
+  "contentEncoding": "utf8",
+  "size": "24",
+  "modifiedDate": "Mar 31 17:56:51 2016",
+  "creationDate": "Mar 31 17:56:51 2016",
+  "customMetaData": {},
+  "contentDisposition": "attachment; filename=\"test-3.pdf\""
+}


### PR DESCRIPTION
Add an option `randomPostKeys` which generates random keys (basename)
for post requests, but preservers dirname and file ending.